### PR TITLE
Add a protobuf serializer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rabble"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Andrew J. Stone <andrew.j.stone.1@gmail.com>"]
 description = "A library for creating location transparent actor based systems"
 repository = "https://github.com/andrewjstone/rabble"
@@ -22,6 +22,7 @@ slog-stdlog = "1"
 slog-term = "1.1"
 slog-envlogger = "0.5"
 ferris = "0.1"
+protobuf = "1.0.24"
 
 [dev-dependencies]
 assert_matches = "1.0"

--- a/src/connection_handler.rs
+++ b/src/connection_handler.rs
@@ -7,7 +7,7 @@ use pid::Pid;
 /// Implement this for a specific connection handler
 pub trait ConnectionHandler : Sized {
     type Msg: Encodable + Decodable + Debug + Clone;
-    type ClientMsg: Encodable + Decodable + Debug;
+    type ClientMsg: Debug;
 
     fn new(pid: Pid, id: u64) -> Self;
     fn handle_envelope(&mut self, Envelope<Self::Msg>) -> &mut Vec<ConnectionMsg<Self>>;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,6 @@
 use std::io;
 use msgpack;
+use protobuf;
 use pid::Pid;
 use node_id::NodeId;
 
@@ -9,6 +10,7 @@ error_chain! {
         io::Error, Io;
         msgpack::encode::Error, MsgpackEncode;
         msgpack::decode::Error, MsgpackDecode;
+        protobuf::error::ProtobufError, Protobuf;
     }
 
     errors {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate error_chain;
 extern crate orset;
 extern crate rustc_serialize;
 extern crate rmp_serialize as msgpack;
+extern crate protobuf;
 extern crate amy;
 extern crate time;
 extern crate net2;
@@ -39,6 +40,7 @@ mod tcp_server_handler;
 mod connection_handler;
 mod serialize;
 mod msgpack_serializer;
+mod protobuf_serializer;
 
 pub mod errors;
 
@@ -61,6 +63,7 @@ pub use connection_handler::{
 };
 pub use serialize::Serialize;
 pub use msgpack_serializer::MsgpackSerializer;
+pub use protobuf_serializer::ProtobufSerializer;
 pub use tcp_server_handler::TcpServerHandler;
 pub use service_handler::ServiceHandler;
 

--- a/src/protobuf_serializer.rs
+++ b/src/protobuf_serializer.rs
@@ -1,0 +1,52 @@
+use std::io::{Read, Write};
+use std::marker::PhantomData;
+use amy::{FrameReader, FrameWriter};
+use protobuf::{Message, MessageStatic, parse_from_bytes};
+use errors::*;
+use serialize::Serialize;
+
+const MAX_FRAME_SIZE: u32 = 64*1024*1024; // 64 MB
+
+pub struct ProtobufSerializer<M: Message + MessageStatic> {
+    frame_reader: FrameReader,
+    frame_writer: FrameWriter,
+    phantom: PhantomData<M>
+}
+
+impl<M: Message + MessageStatic> Serialize for ProtobufSerializer<M> {
+    type Msg = M;
+
+    fn new() -> ProtobufSerializer<M> {
+        ProtobufSerializer {
+            frame_reader: FrameReader::new(MAX_FRAME_SIZE),
+            frame_writer: FrameWriter::new(),
+            phantom: PhantomData
+        }
+    }
+
+    fn read_msg<U: Read>(&mut self, reader: &mut U) -> Result<Option<M>> {
+        try!(self.frame_reader.read(reader).chain_err(|| "Serializer failed to read from socket"));
+        self.frame_reader.iter_mut().next().map_or(Ok(None), |frame| {
+            let msg: M = try!(parse_from_bytes(&frame[..]));
+            Ok(Some(msg))
+        })
+    }
+
+    fn write_msgs<U: Write>(&mut self, writer: &mut U, msg: Option<&M>) -> Result<bool> {
+        if msg.is_none() {
+            return self.frame_writer.write(writer, None)
+                .chain_err(|| "Failed to write encoded message")
+        }
+        let encoded = try!(msg.as_ref().unwrap().write_to_bytes());
+        self.frame_writer.write(writer, Some(encoded))
+            .chain_err(|| "Failed to write encoded message")
+    }
+
+    fn set_writable(&mut self) {
+        self.frame_writer.writable();
+    }
+
+    fn is_writable(&self) -> bool {
+        self.frame_writer.is_writable()
+    }
+}

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,6 +1,5 @@
 use std::io::{Read, Write};
 use std::fmt::Debug;
-use rustc_serialize::{Encodable, Decodable};
 use errors::*;
 
 /// This trait provides for reading framed messages from a `Read` type, decoding them and
@@ -16,7 +15,7 @@ use errors::*;
 /// to minimize memory consumption we just write as much as possible and worry about starvation
 /// management on the reader side.
 pub trait Serialize {
-    type Msg: Encodable + Decodable + Clone + Debug;
+    type Msg: Clone + Debug;
 
     fn new() -> Self;
 


### PR DESCRIPTION
Remove the constraint for Serialized messages to be 'Encodable' and
'Decodable'. Removed the same constraint for the `ClientMsg` type in the
`ConnectionHandler` trait.