### PR TITLE
Fixes for metric reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: rust
 rust:
+  - stable
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rabble"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Andrew J. Stone <andrew.j.stone.1@gmail.com>"]
 description = "A library for creating location transparent actor based systems"
 repository = "https://github.com/andrewjstone/rabble"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub use process::Process;
 pub use envelope::Envelope;
 pub use correlation_id::CorrelationId;
 pub use msg::Msg;
+pub use metrics::Metric;
 
 pub use cluster::{
     ClusterServer,


### PR DESCRIPTION
Ensure metrics for cluster server are properly routed from executor.
Export `Metric` as public for the crate.

bump version