### PR TITLE
Add support for Amy 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["cluster", "networking", "distributed", "actor", "erlang"]
 license = "Apache-2.0"
 
 [dependencies]
-amy = "0.6"
+amy = "0.7"
 orset = "0.1"
 rustc-serialize = "0.3"
 rmp-serialize = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ repository = "https://github.com/andrewjstone/rabble"
 keywords = ["cluster", "networking", "distributed", "actor", "erlang"]
 license = "Apache-2.0"
 
+[features]
+# reexport no_timerfd feature from amy
+no_timerfd = ["amy/no_timerfd"]
+
 [dependencies]
 amy = "0.7"
 orset = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub fn rouse<T>(node_id: NodeId, logger: Option<slog::Logger>) -> (Node<T>, Vec<
     let cluster_server = ClusterServer::new(node_id.clone(),
                                             cluster_rx,
                                             exec_tx.clone(),
-                                            poller.get_registrar(),
+                                            poller.get_registrar().unwrap(),
                                             logger.clone());
     let executor = Executor::new(node_id.clone(),
                                  exec_tx.clone(),

--- a/src/node.rs
+++ b/src/node.rs
@@ -92,7 +92,7 @@ impl<T: Encodable + Decodable + Debug + Clone> Node<T> {
     pub fn register_service(&self, pid: &Pid, tx: &amy::Sender<Envelope<T>>) -> Result<()>
     {
         send!(self.executor_tx,
-              ExecutorMsg::RegisterService(pid.clone(), tx.clone()),
+              ExecutorMsg::RegisterService(pid.clone(), tx.try_clone()?),
               Some(pid),
               format!("ExecutorMsg::RegisterService({}, ..)", pid))
     }

--- a/src/service/service.rs
+++ b/src/service/service.rs
@@ -31,10 +31,10 @@ impl<T, H> Service<T, H>
 {
     pub fn new(pid: Pid, node: Node<T>, mut handler: H) -> Result<Service<T, H>> {
         let poller = Poller::new().unwrap();
-        let registrar = poller.get_registrar();
-        let (tx, rx) = registrar.channel().unwrap();
-        try!(node.register_service(&pid, &tx));
-        try!(handler.init(&registrar, &node));
+        let mut registrar = poller.get_registrar()?;
+        let (tx, rx) = registrar.channel()?;
+        node.register_service(&pid, &tx)?;
+        handler.init(&registrar, &node)?;
         let logger = node.logger.new(o!("component" => "service", "pid" => pid.to_string()));
         Ok(Service {
             pid: pid,

--- a/tests/join_leave.rs
+++ b/tests/join_leave.rs
@@ -7,7 +7,6 @@ extern crate rabble;
 extern crate assert_matches;
 extern crate rustc_serialize;
 
-#[macro_use]
 extern crate slog;
 extern crate slog_stdlog;
 extern crate slog_envlogger;
@@ -47,7 +46,7 @@ fn join_leave() {
     // We register the sender with all nodes so that we can check the responses to admin calls
     // like node.get_cluster_status().
     let mut poller = Poller::new().unwrap();
-    let (test_tx, test_rx) = poller.get_registrar().channel().unwrap();
+    let (test_tx, test_rx) = poller.get_registrar().unwrap().channel().unwrap();
 
     register_test_as_service(&mut poller, &nodes, &test_tx, &test_rx);
 

--- a/tests/multi_node_chain_replication.rs
+++ b/tests/multi_node_chain_replication.rs
@@ -41,7 +41,7 @@ use rabble::{
     CorrelationId
 };
 
-const API_SERVER_IP: &'static str = "127.0.0.1:12001";
+const API_SERVER_IP: &'static str = "127.0.0.1:22001";
 const NUM_NODES: usize = 3;
 
 type CrNode = Node<RabbleUserMsg>;

--- a/tests/multi_node_chain_replication.rs
+++ b/tests/multi_node_chain_replication.rs
@@ -5,7 +5,6 @@ extern crate rabble;
 extern crate assert_matches;
 extern crate rustc_serialize;
 
-#[macro_use]
 extern crate slog;
 extern crate slog_stdlog;
 extern crate slog_envlogger;
@@ -57,7 +56,7 @@ fn chain_replication() {
     // We register the sender with all nodes so that we can check the responses to admin calls
     // like node.get_cluster_status().
     let mut poller = Poller::new().unwrap();
-    let (test_tx, test_rx) = poller.get_registrar().channel().unwrap();
+    let (test_tx, test_rx) = poller.get_registrar().unwrap().channel().unwrap();
 
     register_test_as_service(&mut poller, &nodes, &test_tx, &test_rx);
 

--- a/tests/single_node_chain_replication.rs
+++ b/tests/single_node_chain_replication.rs
@@ -26,7 +26,7 @@ use rabble::{
 };
 
 const CLUSTER_SERVER_IP: &'static str = "127.0.0.1:11001";
-const API_SERVER_IP: &'static str  = "127.0.0.1:12001";
+const API_SERVER_IP: &'static str  = "127.0.0.1:22001";
 
 #[test]
 fn chain_replication() {

--- a/tests/timeout_tests.rs
+++ b/tests/timeout_tests.rs
@@ -5,7 +5,6 @@ extern crate rabble;
 extern crate assert_matches;
 extern crate rustc_serialize;
 
-#[macro_use]
 extern crate slog;
 extern crate slog_stdlog;
 extern crate slog_envlogger;

--- a/tests/timeout_tests.rs
+++ b/tests/timeout_tests.rs
@@ -40,7 +40,7 @@ use rabble::{
 };
 
 const CLUSTER_SERVER_IP: &'static str = "127.0.0.1:11001";
-const API_SERVER_IP: &'static str = "127.0.0.1:12001";
+const API_SERVER_IP: &'static str = "127.0.0.1:22001";
 
 #[test]
 fn connection_timeout() {

--- a/tests/utils/api_server.rs
+++ b/tests/utils/api_server.rs
@@ -33,7 +33,7 @@ pub fn start(node: Node<RabbleUserMsg>)
     let handler: TcpServerHandler<ApiServerConnectionHandler, MsgpackSerializer<ApiClientMsg>> =
         TcpServerHandler::new(server_pid.clone(), API_SERVER_IP, 5000, None);
     let mut service = Service::new(server_pid, node, handler).unwrap();
-    let service_tx = service.tx.clone();
+    let service_tx = service.tx.try_clone().unwrap();
     let service_pid = service.pid.clone();
     let h = thread::spawn(move || {
         service.wait();

--- a/tests/utils/api_server.rs
+++ b/tests/utils/api_server.rs
@@ -17,7 +17,7 @@ use rabble::{
 use super::messages::{RabbleUserMsg, ApiClientMsg};
 
 #[allow(dead_code)] // Not used in all tests
-const API_SERVER_IP: &'static str  = "127.0.0.1:12001";
+const API_SERVER_IP: &'static str  = "127.0.0.1:22001";
 
 #[allow(dead_code)] // Not used in all tests
 pub fn start(node: Node<RabbleUserMsg>)


### PR DESCRIPTION
This allows using Amy on linux without timerfd support. This is useful for really old versions of linux or systems that emulate the linux syscall api but haven't implemented timerfd yet. Note that eventfd support is still required.