### PR TITLE
Rabble manages output envelope vecs for processes and connection handlers

### DIFF
--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -150,8 +150,10 @@ impl Process for Counter {
     type Msg = CounterMsg;
 
     // Each process must implement a single method, `handle`.
-    fn handle(&mut self, msg: Msg<CounterMsg>, from: Pid, correlation_id: Option<CorrelationId>)
-        -> &mut Vec<Envelope<CounterMsg>>
+    fn handle(&mut self, msg: Msg<CounterMsg>,
+              from: Pid,
+              correlation_id: Option<CorrelationId>,
+              output: &mut Vec<Envelope<CounterMsg>>)
     {
         match msg {
           Msg::User(CounterMsg::Inc) => {
@@ -163,20 +165,20 @@ impl Process for Counter {
                   for &b in self.backups {
                       let msg = Msg::User(CounterMsg::Inc);
                       let envelope = Envelope::new(b.clone(), self.pid.clone(), msg, correlation_id);
-                      self.output.push(envelope);
+                      output.push(envelope);
                   }
               } else {
                   // Respond to the primary
                   let reply = Msg::User(CounterMsg::Ok);
                   let envelope = Envelope::new(from, self.pid.clone(), reply, correlation_id);
-                  self.output.push(envelope);
+                  output.push(envelope);
               }
           },
           Msg::User(CounterMsg::GetCount) => {
               // Only the primary gets this message
               let reply = Msg::User(CounterMsg::Count(self.count));
               let envelope = Envelope::new(from, self.pid.clone(), reply, correlation_id);
-              self.output.push(envelope);
+              output.push(envelope);
           },
           Msg::User(CounterMsg::Ok) => {
               // Increment the backup_replies. Once we have received both, reply to the client
@@ -194,12 +196,11 @@ impl Process for Counter {
                   let to = correlation_id.as_ref().unwrap().pid.clone();
                   let reply = CounterMsg::Ok;
                   let envelope = Envelope::new(to, self.pid.clone(), reply, correlation_id);
-                  self.output.push(envelope);
+                  output.push(envelope);
               }
           },
           _ => unreachable!()
         }
-        &mut self.output
     }
 }
 ```
@@ -433,12 +434,12 @@ impl Process for TestProcess {
     fn handle(&mut self,
               msg: Msg<()>,
               from: Pid,
-              correlation_id: Option<CorrelationId>) -> &mut Vec<Envelope<()>>
+              correlation_id: Option<CorrelationId>,
+              output: &mut Vec<Envelope<()>>)
     {
       assert_eq!(from, *self.executor_pid.as_ref().unwrap());
       assert_eq!(msg, Msg::Timeout);
       assert_eq!(correlation_id, None);
-      &mut self.output
     }
 }
 ```

--- a/src/process.rs
+++ b/src/process.rs
@@ -17,6 +17,6 @@ pub trait Process : Send {
     fn handle(&mut self,
               msg: Msg<Self::Msg>,
               from: Pid,
-              correlation_id: Option<CorrelationId>)
-        -> &mut Vec<Envelope<Self::Msg>>;
+              correlation_id: Option<CorrelationId>,
+              output: &mut Vec<Envelope<Self::Msg>>);
 }

--- a/src/service/connection_handler.rs
+++ b/src/service/connection_handler.rs
@@ -10,8 +10,8 @@ pub trait ConnectionHandler : Sized {
     type ClientMsg: Debug;
 
     fn new(pid: Pid, id: u64) -> Self;
-    fn handle_envelope(&mut self, Envelope<Self::Msg>) -> &mut Vec<ConnectionMsg<Self>>;
-    fn handle_network_msg(&mut self, Self::ClientMsg) -> &mut Vec<ConnectionMsg<Self>>;
+    fn handle_envelope(&mut self, Envelope<Self::Msg>, &mut Vec<ConnectionMsg<Self>>);
+    fn handle_network_msg(&mut self, Self::ClientMsg, &mut Vec<ConnectionMsg<Self>>);
 }
 
 /// Connection messages are returned from the callback functions for a Connection.

--- a/tests/timeout_tests.rs
+++ b/tests/timeout_tests.rs
@@ -62,7 +62,6 @@ fn connection_timeout() {
 struct TestProcess {
     pid: Pid,
     executor_pid: Option<Pid>,
-    output: Vec<Envelope<()>>,
 
     /// Don't do this in production!!!
     /// This is only hear to signal to the test that it has received a message.
@@ -85,13 +84,13 @@ impl Process for TestProcess {
     fn handle(&mut self,
               msg: Msg<()>,
               from: Pid,
-              correlation_id: Option<CorrelationId>) -> &mut Vec<Envelope<()>>
+              correlation_id: Option<CorrelationId>,
+              _: &mut Vec<Envelope<()>>)
     {
         assert_eq!(from, *self.executor_pid.as_ref().unwrap());
         assert_eq!(msg, Msg::Timeout);
         assert_eq!(correlation_id, None);
         self.tx.send(()).unwrap();
-        &mut self.output
     }
 }
 
@@ -111,7 +110,6 @@ fn process_timeout() {
     let process = TestProcess {
         pid: pid.clone(),
         executor_pid: None,
-        output: Vec::new(),
         tx: tx
     };
 

--- a/tests/utils/replica.rs
+++ b/tests/utils/replica.rs
@@ -13,8 +13,7 @@ use super::messages::RabbleUserMsg;
 pub struct Replica {
     pid: Pid,
     next: Option<Pid>,
-    history: Vec<usize>,
-    output: Vec<Envelope<RabbleUserMsg>>
+    history: Vec<usize>
 }
 
 #[allow(dead_code)] // Not used in all tests
@@ -23,8 +22,7 @@ impl Replica {
         Replica {
             pid: pid,
             next: next,
-            history: Vec::new(),
-            output: Vec::with_capacity(1)
+            history: Vec::new()
         }
     }
 }
@@ -35,8 +33,8 @@ impl Process for Replica {
     fn handle(&mut self,
               msg: Msg<RabbleUserMsg>,
               _from: Pid,
-              correlation_id: Option<CorrelationId>)
-        -> &mut Vec<Envelope<RabbleUserMsg>>
+              correlation_id: Option<CorrelationId>,
+              output: &mut Vec<Envelope<RabbleUserMsg>>)
     {
         let to = correlation_id.as_ref().unwrap().pid.clone();
         let from = self.pid.clone();
@@ -54,16 +52,15 @@ impl Process for Replica {
                 });
 
                 self.history.push(val);
-                self.output.push(envelope);
+                output.push(envelope);
             },
             Msg::User(RabbleUserMsg::GetHistory) => {
                 let msg = Msg::User(RabbleUserMsg::History(self.history.clone()));
                 let envelope = Envelope::new(to, from, msg, correlation_id);
-                self.output.push(envelope);
+                output.push(envelope);
             },
             _ => ()
         }
-        &mut self.output
     }
 }
 


### PR DESCRIPTION
Change `Process` and `Connection` handler traits to pass in envelope output vecs.

Rabble now manages the output vec of envelopes that get returned as
process output. This allows all processes to share a single vec and
stops requiring each process to allocate its own vec.

Instead of having each connection handler allocate its own vec for
output envelopes, have a single vec allocated by the
`tcp_server_handler`. This results in much less allocations, as there can
be thousands of connections simultaneously, and they can come and go,
each resulting in a new allocation.

Also update docs to reflect changes to `Process` trait and `ConnectionHandler` trait.

Fixes #21